### PR TITLE
Minor updates - adding missing form field attributes

### DIFF
--- a/docs/docs/extensions/syntax-for-forms.md
+++ b/docs/docs/extensions/syntax-for-forms.md
@@ -924,6 +924,7 @@ The `accordion` field can be used to group any number of other fields.
     id: my-accordion
     attributes:
       label: My Accordion
+      icon: gear
     fields:
       - type: boolean
         id: random
@@ -941,7 +942,7 @@ The `accordion` field can be used to group any number of other fields.
       - ...
 ```
 
-The field does not store any values.
+The `icon` attribute can be set to the name of any [Fontawesome icon](https://fontawesome.com/search).  The field does not store any values.
 
 ### Group Field
 

--- a/docs/docs/extensions/syntax-for-forms.md
+++ b/docs/docs/extensions/syntax-for-forms.md
@@ -589,14 +589,14 @@ defaults to `text`.
 
 ![Paragraph Field](../../images/fields/paragraph.png)
 
-The `paragraph` field allows you to display a paragraph of text. The `headline` is optional. There is no `value` for
+The `paragraph` field allows you to display a paragraph of text. The `title` is optional. There is no `value` for
 this field.
 
 ```yaml
   - type: paragraph
     id: paragraph
     attributes:
-      headline: Headline
+      title: Headline
       content: Lorem ipsum dolor sit amet, consetetur sadipscing elitr…
 ```
 

--- a/docs/docs/extensions/syntax-for-forms.md
+++ b/docs/docs/extensions/syntax-for-forms.md
@@ -495,6 +495,24 @@ Resulting `values`:
 }
 ```
 
+Here's an example of how to load a given font from FontBunny:
+
+```js
+function loadFont(fontFamily: string) {
+  // Check if font is already loaded
+  const existingLink = document.querySelector(`link[href*="${fontFamily.replace(/\s+/g, '+')}"]`)
+  if (existingLink) {
+    return
+  }
+
+  // Create and append link element for Bunny Fonts
+  const link = document.createElement('link')
+  link.rel = 'stylesheet'
+  link.href = `https://fonts.bunny.net/css?family=${fontFamily.replace(/\s+/g, '+')}:100,200,300,400,500,600,700,800,900`
+  document.head.appendChild(link)
+}
+```
+
 ### Input Field
 
 ![Input Field](../../images/fields/input.png)


### PR DESCRIPTION
For paragraphs, the `title` attribute works, while `headline` doesn't.

For example, the following settings in `form.yaml`:
<img width="566" height="166" alt="image" src="https://github.com/user-attachments/assets/3d0fe97e-1c37-44dc-8b4c-db6f2f25034e" />

Produce this output, where the "title" value is shown: 
<img width="410" height="110" alt="image" src="https://github.com/user-attachments/assets/a93b090d-6289-45b6-87f4-a0fc5c074cd9" />

-- 

Also, accordions have an "icon" attribute that wasn't documented.

--

I also included a simple JS example for how to load in fonts from FontBunny.
